### PR TITLE
fix: fixes map showing in front of sidebar

### DIFF
--- a/src/components/JourneyMap.vue
+++ b/src/components/JourneyMap.vue
@@ -131,8 +131,8 @@ async function handleActivities(activities) {
       </div>
       <div>
         <div>
-          <div class="rounded-md h-96">
-            <l-map ref="map" v-model:zoom="zoom" v-model:center="center" :use-global-leaflet="false">
+          <div class="rounded-md h-96 z-0">
+            <l-map ref="map" v-model:zoom="zoom" v-model:center="center" :use-global-leaflet="false" class="rounded-md z-0">
               <l-tile-layer
                   url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
                   layer-type="base"


### PR DESCRIPTION
Before
![image](https://github.com/JourneyPlanner/JourneyPlanner/assets/75267822/89c15a53-56a4-4c86-b05b-f1f5c6e6d699)

After
![image](https://github.com/JourneyPlanner/JourneyPlanner/assets/75267822/b1884ecb-a632-4a10-968b-2dac9279fa95)
